### PR TITLE
Changes needed for ocelot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+compiled/
+doc/
+*~

--- a/sdsl/typed-bv/bv.rkt
+++ b/sdsl/typed-bv/bv.rkt
@@ -79,15 +79,17 @@
                  "given ops must be enclosed with braces"
    [⊢ [n ≫ n- ⇐ : Int] ...]
    [⊢ [id ≫ id- ⇒ : ty_id] ... ...]
-   #:fail-unless (stx-andmap (lambda (t) (or (C→? t) (Ccase->? t))) #'(ty_id ... ...))
+   #:fail-unless (stx-andmap concrete-function-type? #'(ty_id ... ...))
                  "given op must be a function"
    ;; outer ~and wrapper is a syntax-parse workaround
-   #:with ((~and (~or (~C→ ty ...)
-                      (~and (~Ccase-> (~C→ ty* ...) ...)
-                            (~parse (ty ...) #'(ty* ... ...))))) ...)
+   #:with ((~and (~or (~and (~C→ ty_in ... ty_out)
+                            (~parse ([ty_in* ... ty_out*] ...) #'([ty_in ... ty_out])))
+                      (~Ccase-> (~C→ ty_in* ... ty_out*) ...))) ...)
           #'(ty_id ... ...)
-   #:fail-unless (stx-andmap τ⊑BV? #'(ty ... ...))
-                 "given op must have BV inputs and output"
+   #:fail-unless (stx-andmap τ⊑BV? #'(ty_in* ... ... ...))
+                 "given op must have BV inputs"
+   #:fail-unless (stx-andmap τ⊑BV? #'(ty_out* ... ...))
+                 "given op must have BV output"
    --------
    [⊢ [_ ≫ (bv:bvlib [{id- ...} n-] ...) ⇒ : Lib]]])
 

--- a/sdsl/typed-fsm/fsm.rkt
+++ b/sdsl/typed-fsm/fsm.rkt
@@ -57,13 +57,14 @@
                  (format "initial state ~a is not declared state: ~a"
                          (syntax->datum #'init-state)
                          (syntax->datum #'(state ...)))
+   #:with col (datum->syntax #f ':)
    #:with arr (datum->syntax #f '→)
    [() ([state ≫ state- : CState] ...) ⊢ 
     [init-state ≫ init-state- ⇐ : CState]
     [target ≫ target- ⇐ : CState] ... ...]
    --------
    [⊢ (fsm:automaton init-state- 
-       [state- : (label arr target-) ...] ...) ⇒ CFSM]]
+       [state- col (label arr target-) ...] ...) ⇒ CFSM]]
   [(_ init-state:id
       [state:id (~datum :) (label:id (~datum →) target) ...] ...) ≫
    #:fail-unless (member (syntax->datum #'init-state)
@@ -71,13 +72,14 @@
                  (format "initial state ~a is not declared state: ~a"
                          (syntax->datum #'init-state)
                          (syntax->datum #'(state ...)))
+   #:with col (datum->syntax #f ':)
    #:with arr (datum->syntax #f '→)
    [() ([state ≫ state- : CState] ...) ⊢ 
     [init-state ≫ init-state- ⇐ : CState]
     [target ≫ target- ⇐ : State] ... ...]
    --------
    [⊢ (fsm:automaton init-state-
-       [state- : (label arr target-) ...] ...) ⇒ FSM]])
+       [state- col (label arr target-) ...] ...) ⇒ FSM]])
 
 ;; (define (apply-FSM f v) (f v))
 ;; (define-primop apply-FSM : (→ FSM (List Symbol) Bool))

--- a/sdsl/typed-synthcl/synthcl.rkt
+++ b/sdsl/typed-synthcl/synthcl.rkt
@@ -1,5 +1,5 @@
 #lang turnstile
-(extends "../../typed/rosette.rkt" #:except ! #%app || && void = * + - / #%datum if assert verify < <= > >=) ; typed rosette
+(extends "../../typed/rosette.rkt" #:except : ! #%app || && void = * + - / #%datum if assert verify < <= > >=) ; typed rosette
 (require (prefix-in ro: (combine-in rosette rosette/lib/synthax))
          (prefix-in cl: "synthcl-model.rkt")
          (only-in "../../typed/rosette.rkt" ~CUnit))
@@ -221,7 +221,7 @@
    #:fail-unless (void? #'ty-out.norm)
                  (format "expected void, given ~a" (type->str #'ty-out.norm))
    --------
-   [≻ (rosette:define (f [x : ty] ... -> void) (⊢m (ro:void) void))]]
+   [≻ (rosette:define (f [x : ty] ...) -> void (⊢m (ro:void) void))]]
   [(_ ty-out:type (f [ty:type x:id] ...) e ... e-body) ≫
    #:with (conv ...) (stx-map get-convert #'(ty.norm ...))
    #:with f- (add-orig (generate-temporary #'f) #'f)

--- a/test/bv-ref-tests.rkt
+++ b/test/bv-ref-tests.rkt
@@ -28,7 +28,7 @@
 (check-type ((bitvector 32) (bvsub (bv 1) (bv1))) : Bool -> #t)
 
 ; Mask off the rightmost 1-bit.
-(define (p1 [x : BV] -> BV)
+(define (p1 [x : BV]) -> BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvand x o1)])
     o2))
@@ -37,79 +37,79 @@
 (check-type ((bitvector 32) (p1 (bv 1))) : Bool -> #t)
 
 ; Test whether an unsigned integer is of the form 2^n-1.
-(define (p2 [x : BV] -> BV)
+(define (p2 [x : BV]) -> BV
   (let* ([o1 (bvadd x (bv 1))]
          [o2 (bvand x o1)])
     o2))
 
 ; Isolate the right most 1-bit.
-(define (p3 [x : BV] -> BV)
+(define (p3 [x : BV]) -> BV
   (let* ([o1 (bvneg x)]
          [o2 (bvand x o1)])
     o2))
 
 ; Form a mask that identifies the rightmost 1-bit and trailing 0s.
-(define (p4 [x : BV] -> BV)
+(define (p4 [x : BV]) -> BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvxor x o1)])
     o2))
 
 ; Right propagate rightmost 1-bit.
-(define (p5 [x : BV] -> BV)
+(define (p5 [x : BV]) -> BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvor x o1)])
     o2))
 
 ; Turn on the right-most 0-bit in a word.
-(define (p6 [x : BV] -> BV)
+(define (p6 [x : BV]) -> BV
   (let* ([o1 (bvadd x (bv 1))]
          [o2 (bvor x o1)])
     o2))
 
 ; Isolate the right most 0 bit of a given bitvector.
-(define (p7 [x : BV] -> BV)
+(define (p7 [x : BV]) -> BV
   (let* ([o1 (bvnot x)]
          [o2 (bvadd x (bv 1))]
          [o3 (bvand o1 o2)])
     o3))
 
 ; Form a mask that identifies the trailing 0s.
-(define (p8 [x : BV] -> BV)
+(define (p8 [x : BV]) -> BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvnot x)]
          [o3 (bvand o1 o2)])
     o3))
 
 ; Absolute value function.
-(define (p9 [x : BV] -> BV)
+(define (p9 [x : BV]) -> BV
   (let* ([o1 (bvashr x (bv 31))]
          [o2 (bvxor x o1)]
          [o3 (bvsub o2 o1)])
     o3))
 
 ; Test if nlz(x) == nlz(y) where nlz is number of leading zeroes.
-(define (p10 [x : BV] [y : BV] ->  BV)
+(define (p10 [x : BV] [y : BV]) ->  BV
   (let* ([o1 (bvand x y)]
          [o2 (bvxor x y)]
          [o3 (bvule o2 o1)])
     o3))
 
 ; Test if nlz(x) < nlz(y) where nlz is number of leading zeroes.
-(define (p11 [x : BV] [y : BV] ->  BV)
+(define (p11 [x : BV] [y : BV]) ->  BV
   (let* ([o1 (bvnot y)]
          [o2 (bvand x o1)]
          [o3 (bvugt o2 y)])
     o3))
 
 ; Test if nlz(x) <= nlz(y) where nlz is number of leading zeroes.
-(define (p12 [x : BV] [y : BV] ->  BV)
+(define (p12 [x : BV] [y : BV]) ->  BV
   (let* ([o1 (bvnot x)]
          [o2 (bvand y o1)]
          [o3 (bvule o2 x)])
     o3))
 
 ; Sign function.
-(define (p13 [x : BV] ->  BV)
+(define (p13 [x : BV]) ->  BV
   (let* ([o1 (bvneg x)]
          [o2 (bvlshr o1 (bv 31))]
          [o3 (bvashr x (bv 31))]
@@ -117,7 +117,7 @@
     o4))
 
 ; Floor of average of two integers without over-flowing.
-(define (p14 [x : BV] [y : BV] ->  BV)
+(define (p14 [x : BV] [y : BV]) ->  BV
   (let* ([o1 (bvand x y)]
          [o2 (bvxor x y)]
          [o3 (bvlshr o2 (bv 1))]
@@ -125,7 +125,7 @@
     o4))
 
 ; Ceil of average of two integers without over-flowing.
-(define (p15 [x : BV] [y : BV] ->  BV)
+(define (p15 [x : BV] [y : BV]) ->  BV
   (let* ([o1 (bvor x y)]
          [o2 (bvxor x y)]
          [o3 (bvlshr o2 (bv 1))]
@@ -133,11 +133,11 @@
     o4))
 
 ; The max function.
-(define (p16 [x : BV] [y : BV] ->  BV)
+(define (p16 [x : BV] [y : BV]) ->  BV
   (if (equal? (bv 1) (bvsge x y)) x y))
 
 ; Turn-off the rightmost contiguous string of 1 bits.
-(define (p17 [x : BV] ->  BV)
+(define (p17 [x : BV]) ->  BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvor x o1)]
          [o3 (bvadd o2 (bv 1))]
@@ -145,7 +145,7 @@
     o4))
 
 ; Test whether an unsigned integer is of the form 2^n.
-(define (p18 [x : BV] -> BV)
+(define (p18 [x : BV]) -> BV
   (let* ([o1 (bvsub x (bv 1))]
          [o2 (bvand o1 x)]
          [o3 (bvredor x)]
@@ -157,7 +157,7 @@
 ; Exchanging 2 fields A and B of the same register 
 ; x where m is mask which identifies field B and k 
 ; is number of bits from end of A to start of B.
-(define (p19 [x : BV] [m : BV] [k : BV] -> BV)
+(define (p19 [x : BV] [m : BV] [k : BV]) -> BV
   (let* ([o1 (bvlshr x k)]
          [o2 (bvxor x o1)]
          [o3 (bvand o2 m)]
@@ -167,7 +167,7 @@
     o6))
 
 ; Next higher unsigned number with the same number of 1 bits.
-(define (p20 [x : BV] -> BV)
+(define (p20 [x : BV]) -> BV
   (let* ([o1 (bvneg x)]
          [o2 (bvand x o1)]
          [o3 (bvadd x o2)]
@@ -178,7 +178,7 @@
     o7))
 
 ; Cycling through 3 values a, b, c.
-(define (p21 [x : BV] [a : BV] [b : BV] [c : BV] -> BV)
+(define (p21 [x : BV] [a : BV] [b : BV] [c : BV]) -> BV
   (let* ([o1 (bveq x c)]
          [o2 (bvneg o1)]
          [o3 (bvxor a c)]
@@ -192,7 +192,7 @@
     o10))
 
 ; Compute parity.
-(define (p22 [x : BV] -> BV)
+(define (p22 [x : BV]) -> BV
   (let* ([o1 (bvlshr x (bv 1))]
          [o2 (bvxor o1 x)]
          [o3 (bvlshr o2 (bv 2))]
@@ -204,7 +204,7 @@
     o8))
 
 ; Counting number of bits.
-(define (p23 [x : BV] -> BV)
+(define (p23 [x : BV]) -> BV
   (let* ([o1  (bvlshr x (bv 1))]
          [o2  (bvand o1 (bv #x55555555))]
          [o3  (bvsub x o2)]
@@ -218,7 +218,7 @@
     o10))
 
 ; Round up to the next higher power of 2.
-(define (p24 [x : BV] -> BV)
+(define (p24 [x : BV]) -> BV
   (let* ([o1  (bvsub x (bv 1))]
          [o2  (bvlshr o1 (bv 1))]
          [o3  (bvor o1 o2)]
@@ -234,7 +234,7 @@
     o12))
 
 ; Compute higher order half of product of x and y.
-(define (p25 [x : BV] [y : BV] -> BV)
+(define (p25 [x : BV] [y : BV]) -> BV
   (let* ([o1  (bvand x (bv #xffff))]
          [o2  (bvlshr x (bv 16))]
          [o3  (bvand y (bv #xffff))]

--- a/test/ifc-tests.rkt
+++ b/test/ifc-tests.rkt
@@ -5,11 +5,11 @@
 
 ;; takes ~90min to run
 
-(define (verify/halted [p : Prog] -> (CU Witness CTrue))
+(define (verify/halted [p : Prog]) -> (CU Witness CTrue)
   (verify-EENI* init halted? mem≈ p))
-(define (verify/halted+low [p : Prog] -> (CU Witness CTrue))
+(define (verify/halted+low [p : Prog]) -> (CU Witness CTrue)
   (verify-EENI* init halted∩low? mem≈ p))
-(define (verify/halted+low/steps [p : Prog] [k : CInt] -> (CU Witness CTrue))
+(define (verify/halted+low/steps [p : Prog] [k : CInt]) -> (CU Witness CTrue)
   (verify-EENI* init halted∩low? mem≈ p k))
 
 ;; basic-bugs --------------------------------------------------

--- a/test/rosette-guide-sec2-tests.rkt
+++ b/test/rosette-guide-sec2-tests.rkt
@@ -32,13 +32,13 @@
 (define-symbolic* n integer?)
 
 ;; TODO: support internal definition contexts
-(define (static -> Bool)
+(define (static) -> Bool
   (let-symbolic (x boolean?) x))
 #;(define (static -> Bool)
  (define-symbolic x boolean? : Bool) ; creates the same constant when evaluated
  x)
  
-(define (dynamic -> Int)
+(define (dynamic) -> Int
   (let-symbolic* (y integer?) y))
 #;(define (dynamic -> Int)
  (define-symbolic* y integer? : Int) ; creates a different constant when evaluated
@@ -55,7 +55,7 @@
 (define sym*2 (dynamic))
 (check-type (eq? sym*1 sym*2) : Bool -> (= sym*1 sym*2))
 
-(define (yet-another-x -> Bool)
+(define (yet-another-x) -> Bool
   (let-symbolic (x boolean?) x))
 
 (check-type (eq? (static) (yet-another-x))
@@ -70,13 +70,13 @@
 (check-type (asserts) : (CListof Bool) -> (list))
 
 ;; sec 2.3
-(define (poly [x : Int] -> Int)
+(define (poly [x : Int]) -> Int
   (+ (* x x x x) (* 6 x x x) (* 11 x x) (* 6 x)))
 
-(define (factored [x : Int] -> Int)
+(define (factored [x : Int]) -> Int
   (* x (+ x 1) (+ x 2) (+ x 2)))
 
-(define (same [p : (C→ Int Int)] [f : (C→ Int Int)] [x : Int] -> Unit)
+(define (same [p : (C→ Int Int)] [f : (C→ Int Int)] [x : Int]) -> Unit
   (assert (= (p x) (f x))))
 
 ; check zeros; all seems well ...
@@ -99,7 +99,7 @@
 
 (require "../typed/query/debug.rkt"
          "../typed/lib/render.rkt")
-(define/debug (factored/d [x : Int] -> Int)
+(define/debug (factored/d [x : Int]) -> Int
   (* x (+ x 1) (+ x 2) (+ x 2)))
 
 (define ucore (debug [integer?] (same poly factored/d 12)))
@@ -122,7 +122,7 @@
  #:with-msg "Expected a non-function Rosette type, given.*integer\\? integer\\?")
 
 
-(define (factored/?? [x : Int] -> Int)
+(define (factored/?? [x : Int]) -> Int
  (* (+ x (??)) (+ x 1) (+ x (??)) (+ x (??))))
 
 
@@ -135,7 +135,7 @@
 (check-type (print-forms binding) : Unit)
 (check-type+output
  (print-forms binding) ->
- "(define (factored/?? (x : Int) -> Int) (* (+ x 3) (+ x 1) (+ x 2) (+ x 0)))")
+ "(define (factored/?? (x : Int)) -> Int (* (+ x 3) (+ x 1) (+ x 2) (+ x 0)))")
 
 ;; typed/rosette should print: 
 ;;  '(define (factored/?? (x : Int) -> Int) (* (+ x 3) (+ x 1) (+ x 2) (+ x 0)))

--- a/test/rosette-guide-sec3-tests.rkt
+++ b/test/rosette-guide-sec3-tests.rkt
@@ -40,13 +40,13 @@
 
 ;; 3.2.1 Symbolic Constants
 
-(define (always-same -> Int)
+(define (always-same) -> Int
   (let-symbolic (x integer?)
     x))
 (check-type (always-same) : Int)
 (check-type (eq? (always-same) (always-same)) : Bool -> #t)
 
-(define (always-different -> Int)
+(define (always-different) -> Int
   (let-symbolic* (x integer?)
     x))
 (check-type (always-different) : Int)

--- a/test/rosette-guide-sec5-tests.rkt
+++ b/test/rosette-guide-sec5-tests.rkt
@@ -44,11 +44,11 @@
  #:with-msg "Missing type annotations for fields")
 (struct square ([side : Nat])
   #:methods gen:viewable
-  [(define (view [self : (Square Nat)] -> Nat) (square-side self))])
+  [(define (view [self : (Square Nat)]) -> Nat (square-side self))])
 (struct circle ([radius : Nat])
   #:transparent
   #:methods gen:viewable
-  [(define (view [self : (Circle Nat)] -> Nat) (circle-radius self))])
+  [(define (view [self : (Circle Nat)]) -> Nat (circle-radius self))])
 ;(define-symbolic b boolean?)
 (define p2 (if b (square 2) (circle 3))) ; p holds a symbolic structure
 (check-type p2 : (U (CSquare Nat) (CCircle Nat)))

--- a/test/rosette-guide-sec6-tests.rkt
+++ b/test/rosette-guide-sec6-tests.rkt
@@ -6,23 +6,23 @@
 ;; 6.2.1 Synthesis library
 
 ;; choose
-(define (div2 [x : BV] -> BV)
+(define (div2 [x : BV]) -> BV
   ([choose bvshl bvashr bvlshr bvadd bvsub bvmul] x (?? (bitvector 8))))
 (define-symbolic i (bitvector 8))
 (check-type+output
  (print-forms
   (synthesize #:forall (list i)
               #:guarantee (assert (equal? (div2 i) (bvudiv i (bv 2 8))))))
- -> "(define (div2 (x : BV) -> BV) (bvlshr x (bv 1 8)))")
+ -> "(define (div2 (x : BV)) -> BV (bvlshr x (bv 1 8)))")
 
 ;; define-synthax
-(define-synthax (nnf [x : Bool] [y : Bool] depth -> Bool)
+(define-synthax (nnf [x : Bool] [y : Bool] depth) -> Bool
  #:base (choose x (! x) y (! y))
  #:else (choose
          x (! x) y (! y)
          ((choose && ||) (nnf x y (- depth 1))
                          (nnf x y (- depth 1)))))
-(define (nnf=> [x : Bool] [y : Bool] -> Bool)
+(define (nnf=> [x : Bool] [y : Bool]) -> Bool
   (nnf x y 1))
 
 (define-symbolic a b boolean?)
@@ -31,12 +31,12 @@
   (synthesize
    #:forall (list a b)
    #:guarantee (assert (equal? (=> a b) (nnf=> a b)))))
- -> "(define (nnf=> (x : Bool) (y : Bool) -> Bool) (|| (! x) y))")
+ -> "(define (nnf=> (x : Bool) (y : Bool)) -> Bool (|| (! x) y))")
 
 ;; 6.2.2 Angelic Execution Library
 
-(define (static -> Int)  (choose 1 2 3))
-(define (dynamic -> Int) (choose* 1 2 3))
+(define (static) -> Int  (choose 1 2 3))
+(define (dynamic) -> Int (choose* 1 2 3))
 (check-type (equal? (static) (static)) : Bool -> #t)
 (define dyn1 (dynamic))
 (define dyn2 (dynamic))

--- a/test/rosette-guide-sec7-tests.rkt
+++ b/test/rosette-guide-sec7-tests.rkt
@@ -90,7 +90,7 @@
             -> (list (cons b '(1 2)) (cons (! b) 3)))
 
 ;; 7.1.3 Symbolic Lifting
-(define (string-length [value : String] -> Nat)
+(define (string-length [value : String]) -> Nat
  (for/all ([str value])
    (racket/string-length str)))
 
@@ -119,10 +119,10 @@
  
 (define limit 1000)
  
-(define (slow [xs : (Listof CInt)] -> (U CFalse Int))
+(define (slow [xs : (Listof CInt)]) -> (U CFalse Int)
   (and (= (length xs) limit) (car (map add1 xs))))
  
-(define (fast [xs : (Listof CInt)] -> (U CFalse Int))
+(define (fast [xs : (Listof CInt)]) -> (U CFalse Int)
   (for/all ([xs xs]) (slow xs)))
 
 (define ys (build-list limit (lambda ([x : CNat]) x)))
@@ -185,7 +185,7 @@
 
 (define-symbolic a1 b1 c1 d1 integer?)
 
-(define (p? [x : Int] -> Bool)
+(define (p? [x : Int]) -> Bool
   (or (eq? x a1) (eq? x b1) (eq? x c1) (eq? x d1)))
 
 (check-type (hash-values (term-cache)) : (CListof Any)); -> (list d1 c1 b1 a1))

--- a/typed/lib/lift.rkt
+++ b/typed/lib/lift.rkt
@@ -6,7 +6,7 @@
 
 (define-typed-syntax define-lift
   [(_ x:id [(pred? ...) racket-fn:id]) ≫
-   [⊢ [pred? ≫ pred?- ⇒ : (t/ro:~C→ _ ...)]] ...
+   [⊢ [pred? ≫ pred?- ⇒ : (t/ro:~C→ _ ... _)]] ...
    [⊢ [racket-fn ≫ racket-fn- ⇒ : (t/ro:~C→ ty1 ty2)]]
    #:with y (generate-temporary #'x)
    --------
@@ -14,7 +14,7 @@
           (define-syntax- x (make-rename-transformer (⊢ y : (t/ro:C→ (t/ro:U ty1) (t/ro:U ty2)))))
           (ro:define-lift y [(pred?- ...) racket-fn-]))]]
   [(_ x:id [pred? racket-fn:id]) ≫
-   [⊢ [pred? ≫ pred?- ⇒ : (t/ro:~C→ _ ...)]]
+   [⊢ [pred? ≫ pred?- ⇒ : (t/ro:~C→ _ ... _)]]
    [⊢ [racket-fn ≫ racket-fn- ⇒ : (t/ro:~C→ ty1 ty2)]]
    #:with y (generate-temporary #'x)
    --------

--- a/typed/lib/synthax.rkt
+++ b/typed/lib/synthax.rkt
@@ -2,7 +2,7 @@
 (require
  (prefix-in 
   t/ro:
-  (only-in "../rosette.rkt" U Int C→ CSolution CUnit CSyntax CListof expand/ro))
+  (only-in "../rosette.rkt" U Int C→ CSolution CUnit CStx CListof expand/ro))
  (prefix-in ro: rosette/lib/synthax))
 
 (provide (typed-out [print-forms : (t/ro:C→ t/ro:CSolution t/ro:CUnit)])
@@ -35,7 +35,7 @@
 (define-syntax generate-forms
   (make-variable-like-transformer
    (assign-type #'ro:generate-forms 
-                #'(t/ro:C→ t/ro:CSolution (t/ro:CListof t/ro:CSyntax)))))
+                #'(t/ro:C→ t/ro:CSolution (t/ro:CListof t/ro:CStx)))))
 
 (define-typed-syntax choose
   [(ch e ...+) ≫
@@ -55,7 +55,7 @@
 ;; - must do some expansion to check types,
 ;;   but dont use expanded stx objs as args to ro:define-synthax
 (define-typed-syntax define-synthax
-  [(_ (f [x (~datum :) ty] ... k (~datum ->) ty-out) #:base be #:else ee) ≫
+  [(_ (f [x (~datum :) ty] ... k) (~datum ->) ty-out #:base be #:else ee) ≫
    #:with f- (generate-temporary #'f)
    #:with (a ...) (generate-temporaries #'(ty ...))
    --------

--- a/typed/query/debug.rkt
+++ b/typed/query/debug.rkt
@@ -6,6 +6,8 @@
 
 (provide define/debug debug)
 
+;; TODO: allow type delarations before the definition using the `:` form
+
 ;; - ideally, I could separate expansion of typed rosette and rosette,
 ;; ie, expansion in ty/ro would stop at ro ids
 ;; - concretely, e cannot be fully expanded bc then it misses
@@ -32,7 +34,7 @@
         ;; and the param'ed app is already gone
         ;; - but using e wont work either due to stx taint errs
         (ro:define/debug y e-))]]
-  [(_ (f [x : ty] ... (~or → ->) ty_out) e ...+) ≫
+  [(_ (f [x : ty] ...) (~or → ->) ty_out e ...+) ≫
    #:with f- (generate-temporary #'f)
    --------
    [≻ (begin-

--- a/typed/rosette.rkt
+++ b/typed/rosette.rkt
@@ -25,14 +25,16 @@
                      [stlc+union:λ lambda])
          (for-syntax get-pred expand/ro)
          Any CNothing Nothing
-         CU U (for-syntax ~U*)
+         CU U (for-syntax ~CU* ~U*)
          Constant
          C→ → (for-syntax ~C→ C→?)
          Ccase-> (for-syntax ~Ccase-> Ccase->?) ; TODO: sym case-> not supported
          CListof Listof CList CPair Pair
+         (for-syntax ~CListof)
          CVectorof MVectorof IVectorof Vectorof CMVectorof CIVectorof CVector
          CParamof ; TODO: symbolic Param not supported yet
          CBoxof MBoxof IBoxof CMBoxof CIBoxof CHashTable
+         (for-syntax ~CHashTable)
          CUnit Unit (for-syntax ~CUnit CUnit?)
          CNegInt NegInt
          CZero Zero
@@ -44,6 +46,7 @@
          CFalse CTrue CBool Bool
          CString String (for-syntax CString?)
          CStx ; symblic Stx not supported
+         CSymbol
          CAsserts
          ;; BV types
          CBV BV

--- a/typed/rosette/base-forms.rkt
+++ b/typed/rosette/base-forms.rkt
@@ -1,0 +1,390 @@
+#lang turnstile
+
+(provide : define λ apply ann begin
+         (rename-out [app #%app])
+         unsafe-assign-type unsafe-define/assign-type
+         (for-syntax expand/ro))
+
+(require (only-in turnstile/examples/stlc+union ann begin)
+         (prefix-in ro: (only-in rosette/safe define λ #%app #%top))
+         "types.rkt")
+
+(begin-for-syntax
+  ;; split-at* : [Listof A] [Listof Natural] -> [Listof [Listof A]]
+  (define (split-at* lst lengths)
+    (cond [(empty? lengths) (list lst)]
+          [else
+           (define-values [fst rst]
+             (split-at lst (first lengths)))
+           (cons fst (split-at* rst (rest lengths)))]))
+  )
+
+;; ----------------------------------------------------------------------------
+
+;; Expanding to Rosette Forms
+
+(begin-for-syntax
+  ;; TODO: fix this so it's not using hardcoded list of ids
+  (define (expand/ro e)
+    (define e+
+      (local-expand
+       e 'expression
+       (list #'ro:#%app #'ro:choose #'ro:synthesize #'ro:let #'ro:in-value
+             #'ro:assert #'ro:if #'ro:? #'ro:verify)))
+;    (displayln (stx->datum e+))
+    e+)
+  (define (mk-ro:-id id) (format-id id "ro:~a" id))
+  (current-host-lang mk-ro:-id))
+
+;; ----------------------------------------------------------------------------
+
+;; Declaring Types before Definitions
+
+(begin-for-syntax
+  (define type-decl-internal-id 'type-decl-internal-id)
+  (define type-decl-internal-id-for 'type-decl-internal-id-for)
+  (define-syntax-class id/type-decl
+    #:attributes [internal-id type]
+    [pattern x:id
+      ;; expand x in such a way that an unbound identifier
+      ;; won't be an error
+      #:with x* (local-expand #'x 'expression #false)
+      #:attr internal-id (syntax-property #'x* type-decl-internal-id)
+      #:when (attribute internal-id)
+      #:with type (typeof #'x*)]))
+
+(define-typed-syntax :
+  #:datum-literals [:]
+  [(_ x:id : τ) ≫
+   #:with x- (generate-temporary #'x)
+   --------
+   [≻ (define-syntax- x
+        (make-variable-like-transformer
+         (set-stx-prop/preserved
+          (set-stx-prop/preserved
+           (⊢ x- : τ)
+           type-decl-internal-id
+           (syntax-local-introduce #'x-))
+          type-decl-internal-id-for
+          (syntax-local-introduce #'x))))]])
+
+;; ----------------------------------------------------------------------------
+
+;; Define and Lambda
+
+(begin-for-syntax
+  (define-syntax-class ->
+    [pattern (~or (~datum →) (~datum ->))]))
+
+;; This new version of define handles keyword arguments,
+;; and also uses make-variable-like-transformer so that
+;; types are preserved accross modules.
+
+(define-typed-syntax define
+  #:datum-literals [:]
+  [(_ x:id : τ e:expr) ≫
+   --------
+   [≻ (begin-
+        (: x : τ)
+        (define x e))]]
+  [(_ x:id/type-decl e:expr) ≫
+   #:with x- (syntax-local-introduce #'x.internal-id)
+   --------
+   [≻ (ro:define x- (ann e : x.type))]]
+  [(_ x:id e:expr) ≫
+   #:with x- (generate-temporary #'x)
+   [⊢ e ≫ e- ⇒ τ]
+   #:with x-/props (transfer-props #'e- (⊢ x- : τ))
+   --------
+   [≻ (begin-
+        (define-syntax- x (make-variable-like-transformer #'x-/props))
+        (ro:define x- e-))]]
+  ;; function with no rest argument
+  [(_ (f:id [x:id : τ_in] ... [kw:keyword y:id : τ_kw e_def:expr] ...)
+      :-> τ_out
+      body ...+) ≫
+   #:with body* (syntax/loc this-syntax (begin body ...))
+   #:with lam (syntax/loc this-syntax
+                (λ ([x : τ_in] ... [kw y : τ_kw e_def] ...)
+                  (ann body* : τ_out)))
+   --------
+   [≻ (define f : (C→ τ_in ... [kw τ_kw] ... τ_out)
+        lam)]]
+  ;; function with rest argument
+  [(_ (f:id [x:id : τ_in] ... [kw:keyword y:id : τ_kw e_def:expr] ... . [rst:id : τ_rst])
+      :-> τ_out
+      body ...+) ≫
+   #:with body* (syntax/loc this-syntax (begin body ...))
+   #:with lam (syntax/loc this-syntax
+                (λ ([x : τ_in] ... [kw y : τ_kw e_def] ... . [rst : τ_rst])
+                  (ann body* : τ_out)))
+   --------
+   [≻ (define f : (C→* [τ_in ...] [[kw τ_kw] ...] #:rest τ_rst τ_out)
+        lam)]]
+  ;; function with type declaration beforehand
+  [(_ (f:id/type-decl . (~and args (:id ... (~seq :keyword [:id :expr]) ...))) body ...+) ≫
+   --------
+   [≻ (define f
+        (λ args (begin body ...)))]])
+
+;; This new version of λ handles keyword arguments.
+
+(define-typed-syntax λ
+  #:datum-literals [:]
+  ;; need expected type, no rest argument
+  [(_ (x:id ... (~seq kw:keyword [y:id e_def:expr]) ...) body)
+   ⇐ (~C→* [τ_in ...] [[kw* τ_kw] ...] τ_out) ≫
+   #:fail-unless (equal? (syntax->datum #'[kw ...])
+                         (syntax->datum #'[kw* ...]))
+   (format "keywords don't match, expected ~a, given ~a"
+           (syntax->datum #'[kw* ...])
+           (syntax->datum #'[kw ...]))
+   [⊢ [e_def ≫ e_def- ⇐ τ_kw] ...]
+   [[x ≫ x-- : τ_in] ... [y ≫ y-- : τ_kw] ... ⊢ body ≫ body- ⇐ τ_out]
+   #:with [[x- ...] [y- ...]] (split-at* (stx->list #'[x-- ... y-- ...])
+                                         (list (length (stx->list #'[x ...]))))
+   #:with [[kw-arg- ...] ...] #'[[kw [y- e_def-]] ...]
+   ---------
+   [⊢ (ro:λ (x- ... kw-arg- ... ...) body-)]]
+  ;; need expected type, with rest argument
+  [(_ (x:id ... . rst:id) e)
+   ⇐ (~C→* [τ_in ...] [] #:rest τ_rst τ_out) ≫
+   [[x ≫ x-- : τ_in] ... [rst ≫ rst-- : τ_rst]
+    ⊢ e ≫ e- ⇐ τ_out]
+   #:with [[x- ...] [rst-]] (split-at* (stx->list #'[x-- ... rst--])
+                                       (list (length (stx->list #'[x ...]))))
+   ---------
+   [⊢ (ro:λ (x- ... . rst-) e-)]]
+  ;; no expected type, keyword arguments
+  [(_ ([x:id : τ_in:type] ... [kw:keyword y:id : τ_kw:type e_def:expr] ...)
+      body) ≫
+   [⊢ [e_def ≫ e_def- ⇐ τ_kw.norm] ...]
+   [[x ≫ x-- : τ_in.norm] ... [y ≫ y-- : τ_kw.norm] ... ⊢ body ≫ body- ⇒ τ_out]
+   #:with [[x- ...] [y- ...]] (split-at* (stx->list #'[x-- ... y-- ...])
+                                         (list (length (stx->list #'[x ...]))))
+   #:with [[kw-arg- ...] ...] #'[[kw [y- e_def-]] ...]
+   -------
+   [⊢ (ro:λ (x- ... kw-arg- ... ...) body-)
+      ⇒ (C→ τ_in ... [kw τ_kw] ... τ_out)]]
+  ;; no expected type, rest argument
+  [(_ ([x:id : τ_in:type] ... [kw:keyword y:id : τ_kw:type e_def:expr] ... . [rst:id : τ_rst:type])
+      body) ≫
+   [⊢ [e_def ≫ e_def- ⇐ τ_kw.norm] ...]
+   [[x ≫ x-- : τ_in.norm] ... [y ≫ y-- : τ_kw.norm] ... [rst ≫ rst-- : τ_rst.norm]
+    ⊢ body ≫ body- ⇒ τ_out]
+   #:with [[x- ...] [y- ...] [rst-]]
+   (split-at* (stx->list #'[x-- ... y-- ... rst--])
+              (list (length (stx->list #'[x ...]))
+                    (length (stx->list #'[y ...]))))
+   #:with [[kw-arg- ...] ...] #'[[kw [y- e_def-]] ...]
+   -------
+   [⊢ (ro:λ (x- ... kw-arg- ... ... . rst-) body-)
+      ⇒ (C→* [τ_in.norm ...] [[kw τ_kw.norm] ...] #:rest τ_rst.norm τ_out)]])
+
+;; ----------------------------------------------------------------------------
+
+;; Function Application
+
+(begin-for-syntax
+  (define (expected-arguments-string τ_f)
+    (syntax-parse τ_f
+      [(~C→* [τ_a ...] [] _) 
+       (string-join (stx-map type->str #'[τ_a ...]) ", ")]
+      [(~C→* [τ_a ...] [[kw τ_b] ...] _)
+       (format
+        "~a [, ~a ]"
+        (string-join (stx-map type->str #'[τ_a ...]) ", ")
+        (string-join
+         (stx-map
+          (λ (kw τ_b)
+            (format "~s ~a" (syntax->datum kw) (type->str τ_b)))
+          #'[kw ...]
+          #'[τ_b ...])
+         ", "))])))
+
+(define-typed-syntax app
+  ;; concrete functions
+  [(_ f:expr a:expr ... (~seq kw:keyword b:expr) ...) ≫
+   ;[⊢ f ≫ f-- ⇒ (~and (~C→* [τ_a ...] [[kw* τ_kw*] ...] τ_out) ~!)]
+   #:with f-- (expand/ro #'f)
+   #:with (~and (~C→* [τ_a ...] [[kw* τ_kw*] ...] τ_out) ~!)
+   (typeof #'f--)
+   #:with f- (replace-stx-loc #'f-- #'f)
+   #:fail-unless (stx-length=? #'[a ...] #'[τ_a ...])
+   (num-args-fail-msg #'f #'[τ_a ...] #'[a ...])
+   #:do [(define kws/τs*
+           (for/list ([kw* (in-list (syntax->datum #'[kw* ...]))]
+                      [τ* (in-list (syntax->list #'[τ_kw* ...]))])
+             (list kw* τ*)))]
+   #:with [τ_b ...]
+   (for/list ([kw (in-list (syntax->list #'[kw ...]))])
+     (define p (assoc (syntax-e kw) kws/τs*))
+     (unless p (raise-syntax-error #f "keyword not in domain of function" kw))
+     (second p))
+   ;[⊢ [a ≫ a- ⇐ τ_a] ...]
+   ;[⊢ [b ≫ b- ⇐ τ_b] ...]
+   #:with [a- ...] (stx-map expand/ro #'[a ...])
+   #:with [b- ...] (stx-map expand/ro #'[b ...])
+   #:with [τ_a* ...] (stx-map typeof #'(a- ...))
+   #:with [τ_b* ...] (stx-map typeof #'(b- ...))
+   #:fail-unless (typechecks? #'[τ_a* ... τ_b* ...] #'[τ_a ... τ_b ...])
+   (typecheck-fail-msg/multi #'[τ_a ... τ_b ...] #'[τ_a* ... τ_b* ...]
+                             #'[a ... b ...])
+   #:with [[kw/b- ...] ...] #'[[kw b-] ...]
+   --------
+   [⊢ (ro:#%app f- a- ... kw/b- ... ...) ⇒ τ_out]]
+  ;; concrete case->
+  [(_ f:expr a:expr ... (~seq kw:keyword b:expr) ...) ≫
+   ;[⊢ f ≫ f- ⇒ (~and (~Ccase-> ~! τ_f ...) ~!)]
+   #:with f-- (expand/ro #'f)
+   #:with (~Ccase-> ~! τ_f ...) (typeof #'f--)
+   #:with f- (replace-stx-loc #'f-- #'f)
+   ;[⊢ [a ≫ a- ⇒ τ_a] ...]
+   ;[⊢ [b ≫ b- ⇒ τ_b] ...]
+   #:with [a- ...] (stx-map expand/ro #'[a ...])
+   #:with [b- ...] (stx-map expand/ro #'[b ...])
+   #:with [τ_a ...] (stx-map typeof #'(a- ...))
+   #:with [τ_b ...] (stx-map typeof #'(b- ...))
+   #:with τ_out
+   (for/or ([τ_f (in-list (stx->list #'[τ_f ...]))])
+     (syntax-parse τ_f
+       [(~C→* [τ_a* ...] [[kw* τ_kw*] ...] τ_out)
+        (define kws/τs*
+          (for/list ([kw (in-list (syntax->datum #'[kw* ...]))]
+                     [τ (in-list (syntax->list #'[τ_kw* ...]))])
+            (list kw τ)))
+        (and (typechecks? #'[τ_a ...] #'[τ_a* ...])
+             (for/and ([kw (in-list (syntax->datum #'[kw ...]))]
+                       [b (in-list (syntax->list #'[b ...]))])
+               (define p (assoc kw kws/τs*))
+               (and p
+                    (typecheck? b (second p))))
+             #'τ_out)]
+       [_ #false]))
+   #:fail-unless (syntax-e #'τ_out)
+   ; use (failing) typechecks? to get err msg
+   (let* ([τs_given #'(τ_a ...)]
+          [expressions #'(a ...)])
+     (format (string-append "type mismatch\n"
+                            "  expected one of:\n"
+                            "    ~a\n"
+                            "  given: ~a\n"
+                            "  expressions: ~a")
+       (string-join
+        (stx-map expected-arguments-string #'[τ_f ...])
+        "\n    ")
+       (string-join (stx-map type->str τs_given) ", ")
+       (string-join (map ~s (stx-map syntax->datum expressions)) ", ")))
+   #:with [[kw/b- ...] ...] #'[[kw b-] ...]
+   --------
+   [⊢ (ro:#%app f- a- ... kw/b- ... ...) ⇒ τ_out]]
+  ;; concrete union functions
+  [(_ f:expr a:expr ... (~seq kw:keyword b:expr) ...) ≫
+   ;[⊢ [f ≫ f-- ⇒ : (~and (~CU* τ_f ...) ~!)]]
+   #:with f-- (expand/ro #'f)
+   #:with (~CU* ~! τ_f ...) (typeof #'f--)
+   #:with f- (replace-stx-loc #'f-- #'f)
+   ;[⊢ [a ≫ a- ⇒ : τ_a] ...]
+   ;[⊢ [b ≫ b- ⇒ : τ_b] ...]
+   #:with (a- ...) (stx-map expand/ro #'(a ...))
+   #:with (b- ...) (stx-map expand/ro #'(b ...))
+   #:with (τ_a ...) (stx-map typeof #'(a- ...))
+   #:with (τ_b ...) (stx-map typeof #'(b- ...))
+   #:with f* (generate-temporary #'f)
+   #:with (a* ...) (generate-temporaries #'(a ...))
+   #:with (b* ...) (generate-temporaries #'(b ...))
+   #:with [[kw/b* ...] ...] #'[[kw b*] ...]
+   [([f* ≫ _ : τ_f] [a* ≫ _ : τ_a] ... [b* ≫ _ : τ_b] ...)
+    ⊢ [(app f* a* ... kw/b* ... ...) ≫ _ ⇒ : τ_out]]
+   ...
+   #:with [[kw/b- ...] ...] #'[[kw b-] ...]
+   --------
+   [⊢ (ro:#%app f- a- ... kw/b- ... ...) ⇒ (CU τ_out ...)]]
+  ;; symbolic functions
+  [(_ f:expr a:expr ... (~seq kw:keyword b:expr) ...) ≫
+   ;[⊢ [f ≫ f-- ⇒ : (~and (~U* τ_f ...) ~!)]]
+   #:with f-- (expand/ro #'f)
+   #:with (~U* ~! τ_f ...) (typeof #'f--)
+   #:with f- (replace-stx-loc #'f-- #'f)
+   ;[⊢ [a ≫ a- ⇒ : τ_a] ...]
+   ;[⊢ [b ≫ b- ⇒ : τ_b] ...]
+   #:with (a- ...) (stx-map expand/ro #'(a ...))
+   #:with (b- ...) (stx-map expand/ro #'(b ...))
+   #:with (τ_a ...) (stx-map typeof #'(a- ...))
+   #:with (τ_b ...) (stx-map typeof #'(b- ...))
+   #:with f* (generate-temporary #'f)
+   #:with (a* ...) (generate-temporaries #'(a ...))
+   #:with (b* ...) (generate-temporaries #'(b ...))
+   #:with [[kw/b* ...] ...] #'[[kw b*] ...]
+   [([f* ≫ _ : τ_f] [a* ≫ _ : τ_a] ... [b* ≫ _ : τ_b] ...)
+    ⊢ [(app f* a* ... kw/b* ... ...) ≫ _ ⇒ : τ_out]]
+   ...
+   #:with [[kw/b- ...] ...] #'[[kw b-] ...]
+   --------
+   [⊢ (ro:#%app f- a- ... kw/b- ... ...) ⇒ (U τ_out ...)]]
+  ;; symbolic constant functions
+  [(_ f:expr a:expr ... (~seq kw:keyword b:expr) ...) ≫
+   ;[⊢ [f ≫ f-- ⇒ : (~and (~Constant* (~U* τ_f ...)) ~!)]]
+   #:with f-- (expand/ro #'f)
+   #:with (~Constant* (~U* τ_f ...)) (typeof #'f--)
+   #:with f- (replace-stx-loc #'f-- #'f)
+   ;[⊢ [a ≫ a- ⇒ : τ_a] ...]
+   ;[⊢ [b ≫ b- ⇒ : τ_b] ...]
+   #:with (a- ...) (stx-map expand/ro #'(a ...))
+   #:with (b- ...) (stx-map expand/ro #'(b ...))
+   #:with (τ_a ...) (stx-map typeof #'(a- ...))
+   #:with (τ_b ...) (stx-map typeof #'(b- ...))
+   #:with f* (generate-temporary #'f)
+   #:with (a* ...) (generate-temporaries #'(a ...))
+   #:with (b* ...) (generate-temporaries #'(b ...))
+   #:with [[kw/b* ...] ...] #'[[kw b*] ...]
+   [([f* ≫ _ : τ_f] [a* ≫ _ : τ_a] ... [b* ≫ _ : τ_b] ...)
+    ⊢ [(app f* a* ... kw/b* ... ...) ≫ _ ⇒ : τ_out]]
+   ...
+   #:with [[kw/b- ...] ...] #'[[kw b-] ...]
+   --------
+   [⊢ [_ ≫ (ro:#%app f- a- ... kw/b- ... ...) ⇒ : (U τ_out ...)]]])
+
+;; ----------------------------------------------------------------------------
+
+;; Apply
+
+;; This version of apply is very limited: it only works with
+;; functions that declare a rest argument.
+
+(define-typed-syntax apply
+  [(_ f:expr lst:expr) ≫
+   [⊢ f ≫ f- ⇒ (~C→* [] [] #:rest τ_rst τ_out)]
+   [⊢ lst ≫ lst- ⇐ τ_rst]
+   --------
+   [⊢ (apply- f- lst-) ⇒ τ_out]]
+  [(_ f:expr lst:expr) ≫
+   [⊢ f ≫ f- ⇒ (~Ccase-> τ_f ...)]
+   [⊢ lst ≫ lst- ⇒ τ_lst]
+   #:with τ_out
+   (for/or ([τ_f (in-list (stx->list #'[τ_f ...]))])
+     (syntax-parse τ_f
+       [(~C→* [] [] #:rest τ_rst* τ_out)
+        (and (typecheck? #'τ_lst #'τ_rst*)
+             #'τ_out)]
+       [_ #false]))
+   #:fail-unless (syntax-e #'τ_out) "none of the cases matched"
+   --------
+   [⊢ (apply- f- lst-) ⇒ τ_out]])
+
+;; ----------------------------------------------------------------------------
+
+;; Unsafely assigning types to values
+
+;; unsafe-assign-type doesn't typecheck anything within the expression
+(define-typed-syntax unsafe-assign-type
+  #:datum-literals [:]
+  [(_ e:expr : τ:expr) ≫
+   --------
+   [⊢ e ⇒ : τ]])
+
+(define-syntax-parser unsafe-define/assign-type
+  #:datum-literals [:]
+  [(_ x:id : τ:expr e:expr)
+   #'(define x (unsafe-assign-type e : τ))])
+

--- a/typed/rosette/types.rkt
+++ b/typed/rosette/types.rkt
@@ -1,0 +1,431 @@
+#lang turnstile
+
+(provide Any
+         CNothing Nothing
+         CU U
+         Constant
+         (for-syntax Any?
+                     ~CU* ~U* CU*? U*?
+                     ~Constant* Constant*? remove-Constant
+                     concrete?)
+         ;; Function types
+         C→ C→* Ccase->
+         →
+         (for-syntax concrete-function-type?
+                     ~C→ ~C→* ~Ccase->
+                     C→? Ccase->?)
+         ;; Parameters
+         CParamof ; TODO: symbolic Param not supported yet
+         ;; List types
+         CListof CList CPair
+         Listof Pair
+         (for-syntax ~CListof ~CList ~CPair)
+         ;; Other container types
+         CHashTable
+         CSequenceof
+         CBoxof CMBoxof CIBoxof MBoxof  IBoxof
+         CVectorof CMVectorof CIVectorof CVector
+         Vectorof MVectorof IVectorof
+         (for-syntax ~CHashTable
+                     ~CSequenceof
+                     ~CMBoxof ~CIBoxof
+                     ~CMVectorof ~CIVectorof)
+         ;; BV types
+         CBV BV
+         CBVPred BVPred
+         ;; Other base types
+         CUnit Unit
+         CZero Zero
+         CPosInt PosInt
+         CNegInt NegInt
+         CNat Nat
+         CInt Int
+         CFloat Float
+         CNum Num
+         CFalse CTrue CBool Bool
+         CString String
+         CStx
+         CSymbol
+         CAsserts
+         COutputPort
+         CSolution CSolver CPict CRegexp CSymbol CPred CPredC
+         (for-syntax ~CUnit CUnit?
+                     ~CString CString?)
+         ;; The relationship between types and
+         ;; rosette's run-time type predicates
+         add-predm
+         add-typeform
+         mark-solvablem
+         mark-functionm
+         (for-syntax get-pred))
+
+(require (only-in turnstile/examples/stlc+union
+           define-named-type-alias prune+sort current-sub?)
+         (prefix-in C
+           (only-in turnstile/examples/stlc+union+case
+             PosInt Zero NegInt Float True False
+             String String?
+             Unit Unit?))
+         (only-in turnstile/examples/stlc+union+case
+           [U CU*] [~U* ~CU*] [U*? CU*?]
+           [case-> Ccase->*] [~case-> ~Ccase->] [case->? Ccase->?]
+           [→ C→/normal] [~→ ~C→/normal] [→? C→/normal?]
+           [~String ~CString]
+           [~Unit ~CUnit])
+         (only-in turnstile/examples/stlc+cons
+           [List CListof] [~List ~CListof])
+         (prefix-in ro: rosette)
+         (prefix-in ro: rosette/lib/synthax)
+         (rename-in "../rosette-util.rkt" [bitvector? lifted-bitvector?]))
+
+;; ---------------------------------
+;; Concrete and Symbolic union types
+
+(begin-for-syntax
+  (define (concrete? t)
+    (not (or (Any? t) (U*? t) (Constant*? t)))))
+
+(define-base-types
+  Any CBV CStx CSymbol CRegexp
+  CSolution CSolver CPict
+  COutputPort)
+
+;; CVectorof includes all vectors
+;; CIVectorof includes only immutable vectors
+;; CMVectorof includes only mutable vectors
+(define-type-constructor CIVectorof #:arity = 1)
+(define-type-constructor CMVectorof #:arity = 1)
+(define-type-constructor CMBoxof #:arity = 1)
+(define-type-constructor CIBoxof #:arity = 1)
+;; TODO: Hash subtyping?
+;; - invariant for now, like TR, though Rosette only uses immutable hashes?
+(define-type-constructor CHashTable #:arity = 2)
+(define-named-type-alias (CVectorof X) (CU (CIVectorof X) (CMVectorof X)))
+(define-named-type-alias (CBoxof X) (CU (CIBoxof X) (CMBoxof X)))
+(define-type-constructor CList #:arity >= 0)
+(define-type-constructor CVector #:arity >= 0)
+(define-type-constructor CPair #:arity = 2)
+
+;; TODO: update orig to use reduced type
+(define-syntax (CU stx)
+  (syntax-parse stx
+    [(_ . tys)
+     #:with tys+ (stx-map (current-type-eval) #'tys)
+     #:fail-unless (stx-andmap concrete? #'tys+)
+                   "CU requires concrete types"
+     #'(CU* . tys+)]))
+
+;; internal symbolic union constructor
+(define-type-constructor U* #:arity >= 0)
+
+;; user-facing symbolic U constructor: flattens and prunes
+(define-syntax (U stx)
+  (syntax-parse stx
+    [(_ . tys)
+     ;; canonicalize by expanding to U*, with only (sorted and pruned) leaf tys
+     #:with ((~or (~U* ty1- ...) (~CU* ty2- ...) ty3-) ...) (stx-map (current-type-eval) #'tys)
+     #:with tys- (prune+sort #'(ty1- ... ... ty2- ... ... ty3- ...))
+     #'(U* . tys-)]))
+
+(define-named-type-alias CNothing (CU))
+(define-named-type-alias Nothing (U))
+
+;; internal symbolic constant constructor
+(define-type-constructor Constant* #:arity = 1)
+
+(define-for-syntax (remove-Constant ty)
+  (syntax-parse ty
+    [(~Constant* t) #'t]
+    [(~U* . tys) ; redo U reductions
+     ((current-type-eval) #`(U . #,(stx-map remove-Constant #'tys)))]
+    [(tycon . tys) 
+     (transfer-stx-props #`(tycon . #,(stx-map remove-Constant #'tys)) ty)]
+    [any ty]))
+     
+;; user-facing symbolic constant constructor: enforce non-concrete type
+(define-syntax Constant
+  (syntax-parser
+    [(_ τ)
+     #:with τ+ ((current-type-eval) #'τ)
+     #:fail-when (and (concrete? #'τ+) #'τ)
+     "Constant requires a symbolic type"
+     #'(Constant* τ+)]))
+
+;; ---------------------------------
+;; case-> and Ccase->
+
+;; Ccase-> must check that its subparts are concrete function types
+(define-syntax Ccase->
+  (syntax-parser
+    [(_ . tys)
+     #:do [(define (concrete-function-type? τ)
+             (or (C→/normal? τ) (C→*/internal? τ)))]
+     #:with tys+ (stx-map (current-type-eval) #'tys)
+     #:fail-unless (stx-andmap concrete-function-type? #'tys+)
+                   "Ccase-> require concrete function types"
+     #'(Ccase->* . tys+)]))
+
+
+;; TODO: What should case-> do when given symbolic function
+;; types? Should it transform (case-> (U (C→ τ ...)) ...)
+;; into (U (Ccase-> (C→ τ ...) ...)) ? What makes sense here?
+
+;; ---------------------------------
+;; Symbolic versions of types
+
+(begin-for-syntax
+  (define (add-pred stx pred)
+    (set-stx-prop/preserved stx 'pred pred))
+  (define (get-pred stx)
+    (syntax-property stx 'pred))
+  (define (add-typefor stx t)
+    (set-stx-prop/preserved stx 'typefor t))
+  (define (get-typefor stx)
+    (syntax-property stx 'typefor))
+  (define (mark-solvable stx)
+    (set-stx-prop/preserved stx 'solvable? #t))
+  (define (set-solvable stx v)
+    (set-stx-prop/preserved stx 'solvable? v))
+  (define (solvable? stx)
+    (syntax-property stx 'solvable?))
+  (define (mark-function stx)
+    (set-stx-prop/preserved stx 'function? #t))
+  (define (set-function stx v)
+    (set-stx-prop/preserved stx 'function? v))
+  (define (function? stx)
+    (syntax-property stx 'function?)))
+
+(define-syntax-parser add-predm
+  [(_ stx pred) (add-pred #'stx #'pred)])
+(define-syntax-parser add-typeform
+  [(_ stx t) (add-typefor #'stx #'t)])
+(define-syntax-parser mark-solvablem
+  [(_ stx) (mark-solvable #'stx)])
+(define-syntax-parser mark-functionm
+  [(_ stx) (mark-function #'stx)])
+
+(define-named-type-alias NegInt (add-predm (U CNegInt) negative-integer?))
+(define-named-type-alias Zero (add-predm (U CZero) zero-integer?))
+(define-named-type-alias PosInt (add-predm (U CPosInt) positive-integer?))
+(define-named-type-alias Float (U CFloat))
+(define-named-type-alias String (U CString))
+(define-named-type-alias Unit (add-predm (U CUnit) ro:void?))
+(define-named-type-alias (CParamof X) (Ccase-> (C→ X)
+                                               (C→ X CUnit)))
+(define-named-type-alias (Listof X) (U (CListof X)))
+(define-named-type-alias (Vectorof X) (U (CVectorof X)))
+(define-named-type-alias (MVectorof X) (U (CMVectorof X)))
+(define-named-type-alias (IVectorof X) (U (CIVectorof X)))
+(define-named-type-alias (MBoxof X) (U (CMBoxof X)))
+(define-named-type-alias (IBoxof X) (U (CIBoxof X)))
+(define-named-type-alias (Pair X Y) (U (CPair X Y)))
+
+(define-syntax →
+  (syntax-parser
+    [(_ ty ...+) 
+     (add-pred
+      (add-orig 
+       #'(U (C→ ty ...)) 
+       this-syntax)
+      #'ro:fv?)]))
+
+(define-syntax define-symbolic-named-type-alias
+  (syntax-parser
+    [(_ Name:id Cτ:expr #:pred p?)
+     #:with Cτ+ ((current-type-eval) #'Cτ)
+     #:fail-when (and (not (concrete? #'Cτ+)) #'Cτ+)
+                 "should be a concrete type"
+     #:with CName (format-id #'Name "C~a" #'Name #:source #'Name)
+     #'(begin-
+         (define-named-type-alias CName Cτ)
+         (define-named-type-alias Name (add-predm (U CName) p?)))]))
+
+(define-symbolic-named-type-alias Bool (CU CFalse CTrue) #:pred ro:boolean?)
+(define-symbolic-named-type-alias Nat (CU CZero CPosInt) #:pred nonnegative-integer?)
+
+(define-symbolic-named-type-alias Int (CU CNegInt CNat) #:pred ro:integer?)
+(define-symbolic-named-type-alias Num (CU CFloat CInt) #:pred ro:real?)
+
+(define-named-type-alias BV (add-predm (U CBV) ro:bv?))
+
+(define-named-type-alias CAsserts (CListof Bool))
+
+;; ---------------------------------------------------------
+
+(define-type-constructor CSequenceof #:arity = 1)
+
+(begin-for-syntax
+  (begin-for-syntax
+    (define-syntax-class expr*
+      [pattern (~and :expr (~not [:keyword . _]))]))
+  (define-syntax-class expr*
+    [pattern (~and :expr (~not [:keyword . _]))]))
+
+;; ---------------------------------------------------------
+
+;; Function Types
+
+(begin-for-syntax
+  (define (C→? τ)
+    (C→*/internal? τ))
+  (define (concrete-function-type? τ)
+    (or (C→? τ) (Ccase->? τ))))
+
+(define-internal-type-constructor C→*/internal) ; #:arity = 4
+(define-internal-type-constructor MandArgs) ; #:arity >= 0
+(define-internal-type-constructor OptKws) ; #:arity >= 1
+
+(define-internal-type-constructor NoRestArg) ; #:arity = 0
+(define-internal-type-constructor RestArg) ; #:arity = 1
+
+(define-internal-type-constructor KwArg) ; #:arity = 2
+
+;; (C→* mandatory-args optional-kws output)
+;; (C→* mandatory-args optional-kws #:rest rest output)
+;;   mandatory-args ::= [τ ...]
+;;     optional-kws ::= [[kw τ] ...]
+;;             rest ::= τ
+;;           output ::= τ
+(define-typed-syntax C→*
+  [(_ [τ_in:expr* ...] [[kw:keyword τ_kw:expr*] ...] τ_out:expr*) ≫
+   [⊢ [τ_in ≫ τ_in- ⇐ :: #%type] ...]
+   [⊢ [τ_kw ≫ τ_kw- ⇐ :: #%type] ...]
+   [⊢ τ_out ≫ τ_out- ⇐ :: #%type]
+   --------
+   [⊢ (C→*/internal- (MandArgs- τ_in- ...)
+                     (OptKws- (KwArg- (quote-syntax kw) τ_kw-) ...)
+                     (NoRestArg-)
+                     τ_out-)
+      ⇒ :: #%type]]
+  [(_ [τ_in:expr* ...] [(~seq kw:keyword τ_kw:expr*) ...] #:rest τ_rst τ_out:expr*) ≫
+   [⊢ [τ_in ≫ τ_in- ⇐ :: #%type] ...]
+   [⊢ [τ_kw ≫ τ_kw- ⇐ :: #%type] ...]
+   [⊢ τ_rst ≫ τ_rst- ⇐ :: #%type]
+   [⊢ τ_out ≫ τ_out- ⇐ :: #%type]
+   --------
+   [⊢ (C→*/internal- (MandArgs- τ_in- ...)
+                     (OptKws- (KwArg- (quote-syntax kw) τ_kw-) ...)
+                     (RestArg- τ_rst-)
+                     τ_out-)
+      ⇒ :: #%type]])
+
+(define-typed-syntax C→
+  [(_ τ_in:expr* ... [kw:keyword τ_kw:expr*] ... τ_out:expr*) ≫
+   --------
+   [≻ (C→* [τ_in ...] [[kw τ_kw] ...] τ_out)]])
+
+(begin-for-syntax
+  (define (convert-opt-kws opt-kws)
+    (syntax-parse opt-kws
+      [(~OptKws (~KwArg ((~literal quote-syntax) kw) τ) ...)
+       #'[[kw τ] ...]]))
+  (define-syntax ~C→*
+    (pattern-expander
+     (syntax-parser
+       [(_ [pat_in:expr* ...] [pat_kw:expr ...] pat_out:expr*)
+        #:with opt-kws (generate-temporary 'opt-kws)
+        #'(~C→*/internal
+           (~MandArgs pat_in ...)
+           (~and opt-kws
+                 (~parse [pat_kw ...] (convert-opt-kws #'opt-kws)))
+           (~NoRestArg)
+           pat_out)]
+       [(_ [pat_in:expr* ...] [pat_kw:expr ...] #:rest pat_rst:expr pat_out:expr*)
+        #:with opt-kws (generate-temporary 'opt-kws)
+        #'(~C→*/internal
+           (~MandArgs pat_in ...)
+           (~and opt-kws
+                 (~parse [pat_kw ...] (convert-opt-kws #'opt-kws)))
+           (~RestArg pat_rst)
+           pat_out)]))))
+
+(begin-for-syntax
+  (define-syntax ~C→
+    (pattern-expander
+     (syntax-parser
+       [(_ pat_in:expr* ... (~and pat_out:expr* (~not (~literal ...))))
+        #'(~C→* [pat_in ...] [] pat_out)]))))
+
+
+;; ---------------------------------------------------------
+
+;; Extra convenience types for predicates
+
+(define-named-type-alias CPred (C→ Any Bool))
+(define-named-type-alias CPredC (C→ Any CBool))
+
+(define-symbolic-named-type-alias BVPred (C→ Any Bool)
+  #:pred lifted-bitvector?)
+
+;; ---------------------------------------------------------
+
+;; Subtyping
+
+(begin-for-syntax
+  (define (sub? t1 t2)
+    ; need this because recursive calls made with unexpanded types
+   ;; (define τ1 ((current-type-eval) t1))
+   ;; (define τ2 ((current-type-eval) t2))
+    ;; (printf "t1 = ~a\n" (syntax->datum t1))
+    ;; (printf "t2 = ~a\n" (syntax->datum t2))
+    (or 
+     (Any? t2)
+     ((current-type=?) t1 t2)
+     (syntax-parse (list t1 t2)
+       ;; Constant clause must appear before U, ow (Const Int) <: Int wont hold
+       [((~Constant* ty1) (~Constant* ty2))
+        (typecheck? #'ty1 #'ty2)]
+       [((~Constant* ty) _) 
+        (typecheck? #'ty t2)]
+       [((~CListof ty1) (~CListof ty2))
+        (typecheck? #'ty1 #'ty2)]
+       [((~CList . tys1) (~CList . tys2))
+        (and (stx-length=? #'tys1 #'tys2)
+             (typechecks? #'tys1 #'tys2))]
+       [((~CList . tys) (~CListof ty))
+        (for/and ([t (stx->list #'tys)])
+          (typecheck? t #'ty))]
+       ;; vectors, only immutable vectors are invariant
+       [((~CIVectorof ty1) (~CIVectorof ty2))
+        (typecheck? #'ty1 #'ty2)]
+       [((~CIBoxof ty1) (~CIBoxof ty2))
+        (typecheck? #'ty1 #'ty2)]
+       [((~CPair ty1a ty1b) (~CPair ty2a ty2b))
+        (and (typecheck? #'ty1a #'ty2a)
+             (typecheck? #'ty1b #'ty2b))]
+       ; 2 U types, subtype = subset
+       [((~CU* . ts1) _)
+        (for/and ([t (stx->list #'ts1)])
+          (typecheck? t t2))]
+       [((~U* . ts1) _)
+        (and
+         (not (concrete? t2))
+         (for/and ([t (stx->list #'ts1)])
+           (typecheck? t t2)))]
+       ; 1 U type, 1 non-U type. subtype = member
+       [(_ (~CU* . ts2))
+        #:when (not (or (U*? t1) (CU*? t1)))
+        (for/or ([t (stx->list #'ts2)])
+          (typecheck? t1 t))]
+       [(_ (~U* . ts2))
+        #:when (not (or (U*? t1) (CU*? t1)))
+        (for/or ([t (stx->list #'ts2)])
+          (typecheck? t1 t))]
+       ; 2 case-> types, subtype = subset
+       [(_ (~Ccase-> . ts2))
+        (for/and ([t (stx->list #'ts2)])
+          (typecheck? t1 t))]
+       ; 1 case-> , 1 non-case->
+       [((~Ccase-> . ts1) _)
+        (for/or ([t (stx->list #'ts1)])
+          (typecheck? t t2))]
+       [((~C→ s1 ... s2) (~C→ t1 ... t2))
+        (and (typechecks? #'(t1 ...) #'(s1 ...))
+             (typecheck? #'s2 #'t2))]
+       [_ #f])))
+  (current-sub? sub?)
+  (current-typecheck-relation sub?)
+  (define (subs? τs1 τs2)
+    (and (stx-length=? τs1 τs2)
+         (stx-andmap (current-sub?) τs1 τs2))))
+


### PR DESCRIPTION
This provides some unprovided types and type pattern-expanders, and adds keyword arguments, rest arguments, and type declarations. 

It also change the syntax for `define`-ing functions from `(define (f [x : τ_in] ... -> τ_out) body)` to `(define (f [x : τ_in] ...) -> τ_out   body)`, so that it can make more consistent with rest argument syntax like `(define (f [x : τ_in] ... . [rst : τ_rst]]) -> τ_out   body)` and `(define (f x ... . rst) body)`.

The type declarations can be used like
```racket
(: f : τ_f)
(define (f x ...) body)
```
And the expected type will be propagated to the body.