### PR TITLE
set new turnstile flag to not use the stop-list optimization; there's…

### DIFF
--- a/typed/rosette.rkt
+++ b/typed/rosette.rkt
@@ -1,4 +1,6 @@
 #lang turnstile
+(begin-for-syntax
+  (current-use-stop-list? #f))
 ;; reuse unlifted forms as-is
 (reuse  
  let* letrec #%datum ann current-join ⊔


### PR DESCRIPTION
… too much that breaks here to easily fix.

Probably best to disable the flag and try and fix these issues if doing significant future work on typed-rosette, in order to take advantage of the performance improvement.